### PR TITLE
자동 커밋 스크립트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# GPT Auto Committer  
-This is a test update from VS Code.
+# GPT Auto Committer
+
+이 저장소는 매일 자동으로 커밋하기 위한 예제 스크립트를 포함합니다.
+
+## 사용 방법
+
+1. `auto_commit.py` 스크립트는 `daily_update.txt` 파일에 현재 시간을 기록하고 Git 커밋 및 푸시를 수행합니다.
+2. 이 스크립트를 `cron` 등에 등록하여 주기적으로 실행하면 됩니다.
+   예시 크론 설정:
+   ```
+   0 9 * * * /usr/bin/python /path/to/auto_commit.py
+   ```
+
+스크립트 실행 전에는 원격 저장소가 설정되어 있어야 하며, 인증 정보가 필요할 수 있습니다.

--- a/auto_commit.py
+++ b/auto_commit.py
@@ -1,0 +1,25 @@
+import subprocess
+from datetime import datetime
+
+
+def run(cmd):
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stderr)
+    return result.stdout.strip()
+
+
+def main():
+    # 현재 시간을 기록하는 파일 업데이트
+    with open('daily_update.txt', 'a') as f:
+        f.write(datetime.now().isoformat() + '\n')
+
+    # git add, commit, push 수행
+    run('git add daily_update.txt')
+    commit_message = f"Automated commit on {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+    run(f"git commit -m \"{commit_message}\"")
+    run('git push')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## 변경 사항
- 매일 자동 커밋을 수행할 수 있는 `auto_commit.py` 스크립트 추가
- 예제 사용법을 README에 한국어로 설명
- 커밋 로그 기록용 `daily_update.txt` 파일 생성

## 테스트
- 별도의 테스트 스크립트가 없어 기본 동작만 확인

------
https://chatgpt.com/codex/tasks/task_e_6884d9bdc8688323ba866f843ac5bd2e